### PR TITLE
fix: Laravel 12 illuminate/contracts support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^10.0||^11.0"
+        "illuminate/contracts": "^10.0||^11.0||^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.14",


### PR DESCRIPTION
This pull request updates composer.json to support Laravel 12 by modifying the illuminate/contracts dependency constraint. Previously, the package only supported Laravel 10 and 11 (^10.0 || ^11.0). This update extends compatibility by adding || ^12.0, ensuring it can be installed in Laravel 12 projects without issues.