### PR TITLE
feat: toggle decimals in CircleProgress

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ return $table
                     'progress' => $progress,
                 ];
             })
-            ->hideProgressValue(),
+            ->hideProgressValue()
+            ->hideDecimals(),
         ProgressBar::make('bar')
             ->getStateUsing(function ($record) {
                 $total = $record->items()->count();

--- a/resources/views/tables/columns/circle-progress.blade.php
+++ b/resources/views/tables/columns/circle-progress.blade.php
@@ -13,7 +13,11 @@
         $progressColor = '#e74c3c';
     }    
     
-    $displayProgress = $progress == 100 ? number_format($progress, 0) : number_format($progress, 2);
+    if ($column->getCanShowDecimals()) {
+        $displayProgress = $progress == 100 ? number_format($progress, 0) : number_format($progress, 2);
+    } else {
+        $displayProgress = number_format($progress, 0);
+    }
 @endphp
 
 <div class="progress-circle" style="

--- a/src/Tables/Columns/CircleProgress.php
+++ b/src/Tables/Columns/CircleProgress.php
@@ -7,6 +7,7 @@ use Filament\Tables\Columns\Column;
 class CircleProgress extends Column
 {
     protected $canShow = true;
+    protected $canShowDecimals = true;
 
     protected string $view = 'filaprogress::tables.columns.circle-progress';
 
@@ -17,8 +18,20 @@ class CircleProgress extends Column
         return $this;
     }
 
+    public function hideDecimals($canShowDecimals = false)
+    {
+        $this->canShowDecimals = $canShowDecimals;
+
+        return $this;
+    }
+
     public function getCanShow(): bool
     {
         return $this->canShow;
+    }
+
+    public function getCanShowDecimals(): bool
+    {
+        return $this->canShowDecimals;
     }
 }


### PR DESCRIPTION
This PR adds the `hideDecimals()` toggle for the `CircleProgress` component.

Example:

```php
CircleProgress::make('circle')
    ->label('Reliability')
    ->translateLabel()
    ->hideDecimals()
    ->getStateUsing(
        fn(Player $record) => ['total' => 100, 'progress' => $record->rd_percent]
    )
```

![image](https://github.com/user-attachments/assets/ab431a2a-afe7-4e83-8975-4230f0dfc064)
